### PR TITLE
Update Zoom version to 2.8.183302.0415 (2019-04-15)

### DIFF
--- a/us.zoom.Zoom.appdata.xml
+++ b/us.zoom.Zoom.appdata.xml
@@ -24,6 +24,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release date="2019-04-15" version="2.8.183302.0415"/>
     <release date="2019-01-20" version="2.7.162522.0121"/>
     <release date="2018-12-16" version="2.6.149990.1216"/>
     <release date="2018-11-30" version="2.6.146750.1204"/>

--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -69,17 +69,17 @@
                     "type": "extra-data",
                     "filename": "zoom.tar.xz",
                     "only-arches": ["x86_64"],
-                    "url": "https://zoom.us/client/2.7.162522.0121/zoom_x86_64.tar.xz",
-                    "sha256": "2103e1a7f665023b06352b91afc1cf7bd97631e38b401729ab63725527792406",
-                    "size": 65920856
+                    "url": "https://zoom.us/client/2.8.183302.0415/zoom_x86_64.tar.xz",
+                    "sha256": "5df085e47c9b67a1c24b20112d343afa22c537726cec5abdac09784782c14e1d",
+                    "size": 66325584
                 },
                 {
                     "type": "extra-data",
                     "filename": "zoom.tar.xz",
                     "only-arches": ["i386"],
-                    "url": "https://zoom.us/client/2.7.162522.0121/zoom_i686.tar.xz",
-                    "sha256": "0b121a5069d819fcfc26e51b7ca19f8a50780658e1e4e1c20d35023b381e57d3",
-                    "size": 41791208
+                    "url": "https://zoom.us/client/2.8.183302.0415/zoom_i686.tar.xz",
+                    "sha256": "e98ffc8d54d13b678cffcaed946aec5ee9d4bfdc2146cc8843e25a7d1f758a29",
+                    "size": 42291084
                 }
             ]
         }


### PR DESCRIPTION
[Release Notes](https://support.zoom.us/hc/en-us/articles/205759689-New-Updates-for-Linux)

Features:
- Option to Disable Chat During a Meeting
- Call a CRC device without Starting a Meeting
- Consent to Being Recorded Confirmation
- Automatically Save Whiteboard
- Show Which Participant is Annotating
- Display an Indicator for Audio Watermark
- Support for Logging in to Multiple Devices
- Accessibility Enhancements
- Star Individual Messages
- Star Contacts and Chat Channels

Fixes:
- Resolved an issue where Brasilia’s time zone was displaying incorrectly
- Resolved an issue where Zoom was crashing for some Linux users after
  annotating
- Bug Fixes