### PR TITLE
Update zoom.tar.xz to 3.0.285090.0826

### DIFF
--- a/us.zoom.Zoom.appdata.xml
+++ b/us.zoom.Zoom.appdata.xml
@@ -24,6 +24,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="3.0.285090.0826" date="2019-08-27"/>
     <release date="2019-07-14" version="2.8.264592.0714"/>
     <release date="2019-06-16" version="2.8.252201.0616"/>
     <release date="2019-05-19" version="2.8.222599.0519"/>

--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -74,9 +74,9 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://d11yldzmag5yn.cloudfront.net/prod/2.8.264592.0714/zoom_x86_64.tar.xz",
-                    "sha256": "7c3701bb0476db215e976d93c05c85bb9353ac07ead17df6414453aebcd7b959",
-                    "size": 66361592,
+                    "url": "https://d11yldzmag5yn.cloudfront.net/prod/3.0.285090.0826/zoom_x86_64.tar.xz",
+                    "sha256": "8591883c019359fe9aa8cb30bcdc2335777e04fcc21606a8e230301a6259372f",
+                    "size": 70489228,
                     "x-checker-data": {
                         "type": "rotating-url",
                         "url": "https://zoom.us/client/latest/zoom_x86_64.tar.xz",
@@ -89,9 +89,9 @@
                     "only-arches": [
                         "i386"
                     ],
-                    "url": "https://d11yldzmag5yn.cloudfront.net/prod/2.8.264592.0714/zoom_i686.tar.xz",
-                    "sha256": "8e926c70837aa05c51dd6f73f224c2f3c29e9511f43398fb20b85bf5fbac08f0",
-                    "size": 42433520,
+                    "url": "https://d11yldzmag5yn.cloudfront.net/prod/3.0.285090.0826/zoom_i686.tar.xz",
+                    "sha256": "57f16784542daeb32da478a33bcc6e635f29b08e4991f3fb43aeac9f8dfd800d",
+                    "size": 45648708,
                     "x-checker-data": {
                         "type": "rotating-url",
                         "url": "https://zoom.us/client/latest/zoom_i686.tar.xz",


### PR DESCRIPTION
Supersedes #32; this was generated by https://github.com/endlessm/flatpak-external-data-checker/pull/34 which adds support for updating appdata.