### PR TITLE
Install zoomus.conf to app

### DIFF
--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -12,7 +12,10 @@
         "--share=network",
         "--device=all",
         "--env=QT_QPA_PLATFORM=",
-        "--own-name=org.kde.*"
+        "--own-name=org.kde.*",
+        "--filesystem=xdg-documents",
+        "--filesystem=xdg-videos",
+        "--persist=.zoom"
     ],
     "modules": [
         {

--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -26,7 +26,8 @@
                 "install -Dm644 us.zoom.Zoom.96.png /app/share/icons/hicolor/96x96/apps/us.zoom.Zoom.png",
                 "install -Dm644 us.zoom.Zoom.128.png /app/share/icons/hicolor/128x128/apps/us.zoom.Zoom.png",
                 "install -Dm644 us.zoom.Zoom.256.png /app/share/icons/hicolor/256x256/apps/us.zoom.Zoom.png",
-                "install -Dm755 zoom.sh /app/bin/zoom"
+                "install -Dm755 zoom.sh /app/bin/zoom",
+                "install -Dm644 zoomus.conf /app/etc/zoomus.conf"
             ],
             "sources": [
                 {
@@ -41,6 +42,8 @@
                     "type": "script",
                     "dest-filename": "zoom.sh",
                     "commands": [
+                        "mkdir -p $XDG_CONFIG_HOME",
+                        "test -e $XDG_CONFIG_HOME/zoomus.conf || cp /app/etc/zoomus.conf $XDG_CONFIG_HOME/zoomus.conf",
                         "exec env TMPDIR=$XDG_CACHE_HOME /app/extra/zoom/ZoomLauncher \"$@\""
                     ]
                 },
@@ -67,6 +70,10 @@
                 {
                     "type": "file",
                     "path": "us.zoom.Zoom.256.png"
+                },
+                {
+                    "type": "file",
+                    "path": "zoomus.conf"
                 },
                 {
                     "type": "extra-data",

--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -11,7 +11,6 @@
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",
-        "--filesystem=home",
         "--env=QT_QPA_PLATFORM=",
         "--own-name=org.kde.*"
     ],

--- a/zoomus.conf
+++ b/zoomus.conf
@@ -1,0 +1,2 @@
+[General]
+enableWaylandShare=true


### PR DESCRIPTION
This changes sandbox enough that we can install app-vendored zoomus.conf that should workaround #22 