### PR TITLE
Set home filesystem access to read only

### DIFF
--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -11,7 +11,10 @@
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",
-        "--filesystem=home"
+        "--filesystem=home:ro",
+        "--filesystem=xdg-download",
+        "--filesystem=xdg-config/zoomus.conf:create",
+        "--filesystem=~/.zoom:create"
     ],
     "modules": [
         {


### PR DESCRIPTION
Add overrides for config files and download directory.

Fix #18 similar to com.skype.Client flatpak.