### PR TITLE
Revert "add wayland socket"

### DIFF
--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -7,8 +7,7 @@
     "separate-locales": false,
     "finish-args": [
         "--share=ipc",
-        "--socket=wayland",
-        "--socket=fallback-x11",
+        "--socket=x11",
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",


### PR DESCRIPTION
This reverts commit 8ae3b6ff85c2fd13c3eebb9c02e742aa9e621298.

The binary of Qt that zoom bundles doesn't provide any kind
of Wayland support, which in combination with the --fallback-x11
permsission breaks completly the application in Wayland sessions
as it restricts the Xorg socket from being available in the sandbox
and thus Qt fails to find a working backend at all.

Close #24