### PR TITLE
Don't try to preserve zoom.tar.xz content file owners

### DIFF
--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -32,7 +32,7 @@
                     "type": "script",
                     "dest-filename": "apply_extra",
                     "commands": [
-                        "tar xf zoom.tar.xz",
+                        "tar xf zoom.tar.xz --no-same-owner",
                         "rm -f zoom.tar.xz"
                     ]
                 },


### PR DESCRIPTION
When extracting as root (i.e. when `flatpak` was run with root
privileges), tar defaults to `--same-owner`, which leads to lots
of ownership change errors like:
```
tar: zoom/libquazip.so: Cannot change ownership to uid 1000, gid 1000: Operation not permitted
tar: zoom/libquazip.so.1: Cannot change ownership to uid 1000, gid 1000: Operation not permitted
tar: zoom/libturbojpeg.so: Cannot change ownership to uid 1000, gid 1000: Operation not permitted
tar: zoom/dingdong1.pcm: Cannot change ownership to uid 1000, gid 1000: Operation not permitted
tar: zoom/libfaac1.so: Cannot change ownership to uid 1000, gid 1000: Operation not permitted
tar: zoom/ring.pcm: Cannot change ownership to uid 1000, gid 1000: Operation not permitted
```
This happens because zoom.tar.xz has `levi(1000):levi(1000)` as
file owner.

This commit adds the `--no-same-owner` tar option.

The full `flatpak update` log is attached: [us.zoom.Zoom.log](https://github.com/flathub/us.zoom.Zoom/files/4455901/us.zoom.Zoom.log)