### PR TITLE
Allow owning org.kde.* for tray icon

### DIFF
--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -11,7 +11,8 @@
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",
-        "--filesystem=home"
+        "--filesystem=home",
+        "--own-name=org.kde.*"
     ],
     "modules": [
         {


### PR DESCRIPTION
I am not clear on the details, but I understand that the KStatusNotifier
protocol involves apps owning bus names of the form
org.kde.KStatusNotifier-x-y where x is the application's PID and y is
some application-determined unique identifier. In the case of (the
current version of) Zoom running in (the current version of) this
Flatpak, it ends up wanting to own org.kde.StatusNotifierItem-8-2.

Allow the app to own all names in this namespace, which allows it to
display a tray icon on (at least) a GNOME(ish) desktop with
https://github.com/ubuntu/gnome-shell-extension-appindicator/ installed.

Fixes #144.