### PR TITLE
Add StartupWMClass to desktop file.

### DIFF
--- a/us.zoom.Zoom.desktop
+++ b/us.zoom.Zoom.desktop
@@ -8,3 +8,4 @@ Type=Application
 StartupNotify=true
 Categories=GNOME;GTK;Network;InstantMessaging;
 MimeType=x-scheme-handler/zoommtg;
+StartupWMClass=zoom


### PR DESCRIPTION
Add StartupWMClass to desktop file to enable adding it to the favourites on the taskbar in Budgie and others.

Previous discussion here: [https://github.com/flathub/us.zoom.Zoom/pull/145](https://github.com/flathub/us.zoom.Zoom/pull/145)