### PR TITLE
Harden sandbox; move content from ~/.zoom to ~/.var/app/us.zoom.Zoom/.zoom

### DIFF
--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -11,10 +11,11 @@
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",
-        "--filesystem=home",
+        "--filesystem=xdg-documents/Zoom:create",
         "--env=QT_QPA_PLATFORM=",
         "--own-name=org.kde.*",
-        "--talk-name=org.freedesktop.ScreenSaver"
+        "--talk-name=org.freedesktop.ScreenSaver",
+        "--persist=.zoom"
     ],
     "modules": [
         {


### PR DESCRIPTION
Hello,

as you may have known, Zoom has had a lot of privacy and security issues in the past.

My friend and I decided to restrict $HOME so we do not risk users' privacy (some examples mentioned in https://github.com/flatpak/flatpak/issues/3637#issuecomment-633774604) and users' security (mentioned in https://github.com/flatpak/flatpak/issues/3637#issue-624448539). We also have not sacrificed convenience.

What we have done:

- removed rw access to $HOME (`--filesystem=home`);
- the only directories that Zoom has permissions to are: `xdg-documents/Zoom:create`, instead of the whole $HOME:rw (`--filesystem=home`).
- all the contents have now moved from `~/.zoom` to `~/.var/app/us.zoom.Zoom/.zoom`.