### PR TITLE
Update StartupWMClass name

### DIFF
--- a/us.zoom.Zoom.desktop
+++ b/us.zoom.Zoom.desktop
@@ -10,4 +10,4 @@ StartupNotify=true
 Categories=Network;InstantMessaging;VideoConference;Telephony;
 MimeType=x-scheme-handler/zoommtg;x-scheme-handler/zoomus;x-scheme-handler/tel;x-scheme-handler/callto;x-scheme-handler/zoomphonecall;application/x-zoom
 X-KDE-Protocols=zoommtg;zoomus;tel;callto;zoomphonecall;
-StartupWMClass=Zoom
+StartupWMClass=zoom


### PR DESCRIPTION
In order to avoid some launchers (like Plank) to display a second, less quality icon, the StartupWMClass needs to match the `WM_CLASS` of the window.

Doing `xprop WM_CLASS` and clicking on the opened window, we can see `WM_CLASS` is actually `zoom` instead of `Zoom`.