### PR TITLE
Rewrite zoom.sh for Wayland screenshare

### DIFF
--- a/zoom.sh
+++ b/zoom.sh
@@ -1,16 +1,22 @@
-##!/usr/bin/env bash
+#!/usr/bin/env bash
 
-# Zoom hardcodes ~/.config instead of using XDG_CONFIG_HOME.
-ZOOMUS=$HOME/.var/app/us.zoom.Zoom/.config/zoomus.conf
+# Check if the current desktop is using Wayland
+if [[ "$XDG_SESSION_TYPE" == "wayland" ]]; then
 
-# Check if ~/.var/app/us.zoom.Zoom/.config/zoomus.conf exists.
-if [[ -f "$ZOOMUS" ]]; then
-    :
-else
-    ln -s $HOME/.var/app/us.zoom.Zoom/config/ ~/.var/app/us.zoom.Zoom/.config
+	# Check if the line 'enableWaylandShare' is set to 'true' in $HOME/.var/app/us.zoom.Zoom/config/zoomus.conf
+	if ! grep -q enableWaylandShare=true "$HOME/.var/app/$FLATPAK_ID/config/zoomus.conf"; then
+
+		# Replace enableWaylandShare=false to enableWaylandShare=true
+		sed -i 's/enableWaylandShare\=false/enableWaylandShare\=true/' ~/.var/app/$FLATPAK_ID/config/zoomus.conf
+
+		# Recheck if the line 'enableWaylandShare' is set to true in $HOME/.var/app/us.zoom.Zoom/config/zoomus.conf
+		if ! grep -q enableWaylandShare=true "$HOME/.var/app/$FLATPAK_ID/config/zoomus.conf"; then
+
+			# If not, create a GTK dialog that says the string inside '--text'
+        	       	zenity --error --text="Wayland screen sharing is not yet enabled. Please restart Zoom for it to automatically enable, or manually change the value of \"enableWaylandShare\" to \"true\" in \"$HOME/.var/app/$FLATPAK_ID/config/zoomus.conf\"."
+
+		fi
+       	fi
 fi
-
-# Enable Wayland
-sed -i 's/enableWaylandShare\=false/enableWaylandShare\=true/' ~/.var/app/us.zoom.Zoom/config/zoomus.conf
 
 exec env TMPDIR=$XDG_CACHE_HOME /app/extra/zoom/ZoomLauncher "$@"


### PR DESCRIPTION
Currently, the [script](https://github.com/flathub/us.zoom.Zoom/blob/f87bc46751831fa57c91bbec0c39fb36e4dbaabc/zoom.sh) only outputs an error in the console, telling you there is an error that `sed -i 's/enableWaylandShare\=false/enableWaylandShare\=true/' ~/.var/app/us.zoom.Zoom/config/zoomus.conf` did not work because `~/.var/app/us.zoom.Zoom/config/zoomus.conf` did not exist. This only occurs the very first time you run Zoom without its `XDG_CONFIG_HOME` directory. The second launch will run the `sed` command successfully. The user only gets notified about this when running on the console: `flatpak run us.zoom.Zoom`.

This MR suggests a better way for this. The script will now run [Zenity](https://en.wikipedia.org/wiki/Zenity), and prompt the user to restart Zoom when they launch Zoom for the very first time without its `XDG_CONFIG_HOME` directory. The script checks if you're using Wayland, so if you are using Xorg, you won't get the prompt.

![image](https://user-images.githubusercontent.com/50847364/102909621-3ce5ec00-4447-11eb-959c-65e1038049dc.png)
