### PR TITLE
Now respecting XDG_DOCUMENTS_DIR variables

### DIFF
--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -14,7 +14,7 @@
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",
-        "--filesystem=~/Documents/Zoom:create",
+        "--filesystem=xdg-documents/Zoom:create",
         "--filesystem=~/.zoom:create",
         "--env=QT_QPA_PLATFORM=",
         "--own-name=org.kde.*",


### PR DESCRIPTION
Using the correct way to reference the /home/user/Documents folder that was previously hardcoded.