### PR TITLE
Enable Wayland socket by default

### DIFF
--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -11,6 +11,7 @@
     "finish-args": [
         "--share=ipc",
         "--socket=x11",
+        "--socket=wayland",
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",


### PR DESCRIPTION
Zoom appears to work with Wayland, so we should enable the socket by default.