### PR TITLE
Enable access to PipeWire for screen-sharing

### DIFF
--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -14,6 +14,7 @@
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",
+        "--filesystem=xdg-run/pipewire-0",
         "--filesystem=~/Documents/Zoom:create",
         "--filesystem=~/.zoom:create",
         "--env=QT_QPA_PLATFORM=",


### PR DESCRIPTION
This has been proven to work only with com.google.Chrome from flathub-beta.