### PR TITLE
Added Wayland Support

### DIFF
--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -10,6 +10,7 @@
     ],
     "finish-args": [
         "--share=ipc",
+        "--socket=wayland",
         "--socket=x11",
         "--socket=pulseaudio",
         "--share=network",


### PR DESCRIPTION
Added the Wayland socket since Wayland works perfectly fine with: QT_QPA_PLATFORM=WAYLAND
Zoom just needs to add the automatic Wayland switch, but now it still works manually.