### PR TITLE
Restore sandbox using zypak (fixes launching with arguments)

### DIFF
--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -1,5 +1,7 @@
 {
     "app-id": "us.zoom.Zoom",
+    "base": "org.electronjs.Electron2.BaseApp",
+    "base-version": "21.08",
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
@@ -34,7 +36,9 @@
                 "install -Dm644 us.zoom.Zoom.96.png /app/share/icons/hicolor/96x96/apps/us.zoom.Zoom.png",
                 "install -Dm644 us.zoom.Zoom.128.png /app/share/icons/hicolor/128x128/apps/us.zoom.Zoom.png",
                 "install -Dm644 us.zoom.Zoom.256.png /app/share/icons/hicolor/256x256/apps/us.zoom.Zoom.png",
-                "install -Dm755 zoom.sh /app/bin/zoom"
+                "install -Dm755 zoom.sh /app/bin/zoom",
+                "install -Dm755 zoom-wrapper.sh /app/bin/zoom-wrapper.sh",
+                "install -Dm644 zoom-ld.so.conf /app/etc/ld.so.conf"
             ],
             "sources": [
                 {
@@ -42,12 +46,22 @@
                     "dest-filename": "apply_extra",
                     "commands": [
                         "tar xf zoom.tar.xz --no-same-owner",
-                        "rm -f zoom.tar.xz"
+                        "rm -f zoom.tar.xz",
+                        "mv /app/extra/zoom/zoom /app/extra/zoom/zoom.real",
+                        "cp /app/bin/zoom-wrapper.sh /app/extra/zoom/zoom"
                     ]
                 },
                 {
                     "type": "file",
                     "path": "zoom.sh"
+                },
+                {
+                    "type": "file",
+                    "path": "zoom-wrapper.sh"
+                },
+                {
+                    "type": "file",
+                    "path": "zoom-ld.so.conf"
                 },
                 {
                     "type": "file",

--- a/zoom-ld.so.conf
+++ b/zoom-ld.so.conf
@@ -1,0 +1,2 @@
+/app/extra/zoom
+/app/extra/zoom/cef

--- a/zoom-wrapper.sh
+++ b/zoom-wrapper.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exec zypak-wrapper "$(readlink -f "$0")".real "$@"

--- a/zoom.sh
+++ b/zoom.sh
@@ -19,4 +19,4 @@ if [[ "$XDG_SESSION_TYPE" == "wayland" ]]; then
        	fi
 fi
 
-exec env TMPDIR=$XDG_CACHE_HOME /app/extra/zoom/ZoomLauncher --no-sandbox "$@"
+TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID" exec /app/extra/zoom/ZoomLauncher "$@"


### PR DESCRIPTION
This restores the sandboxing in a way that it actually is sandboxed, using <https://github.com/refi64/zypak>.

There are two hacks here:

1. If we use zypak-wrapper around ZoomLauncher, LD_PRELOAD gets stripped and the sandbox doesn't work. Therefore, /app/extra/zoom/zoom is renamed to zoom.real and replaced with a wrapper that invokes zypak-wrapper.

2. Zypak invokes the sandbox using flatpak sandboxing, so it's not a child process and doesn't inherit LD_LIBRARY_PATH. As a workaround, the necessary paths are hardcoded in /app/etc/ld.so.conf.

Fixes: https://github.com/flathub/us.zoom.Zoom/issues/326
Fixes: https://github.com/flathub/us.zoom.Zoom/issues/327
