### PR TITLE
zoom.sh: Lie to Zoom about the desktop in Wayland

### DIFF
--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -13,6 +13,7 @@
     "finish-args": [
         "--share=ipc",
         "--socket=x11",
+        "--socket=wayland",
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",

--- a/zoom.sh
+++ b/zoom.sh
@@ -17,6 +17,8 @@ if [[ "$XDG_SESSION_TYPE" == "wayland" ]]; then
 
 		fi
        	fi
+        # Force XDG_CURRENT_DESKTOP to 'gnome' so that Zoom will not block portal screensharing
+        XDG_CURRENT_DESKTOP="gnome"
 fi
 
 TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID" exec /app/extra/zoom/ZoomLauncher "$@"


### PR DESCRIPTION
Zoom employs a check for Wayland screensharing to only allow it when
it detects that GNOME is the running desktop. However, since Zoom
5.11.0, Wayland screensharing is done through the XDG desktop portal
mechanism, and thus is desktop independent.

Unfortunately, the check is still in place, and in order to allow
Wayland screen sharing to work on KDE Plasma and other Wayland
environments, we need to lie to Zoom to allow it through.

Thus, we set XDG_CURRENT_DESKTOP to "gnome" whenever we detect we
are running Zoom in a Wayland environment to satisfy the check.

Fixes #307 