### PR TITLE
use subdirectory of Freedesktop user directories for recordings

### DIFF
--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -17,7 +17,7 @@
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",
-        "--filesystem=~/Documents/Zoom:create",
+        "--filesystem=xdg-documents/Zoom:create",
         "--persist=.zoom",
         "--env=QT_QPA_PLATFORM=",
         "--own-name=org.kde.*",

--- a/zoom.sh
+++ b/zoom.sh
@@ -9,4 +9,10 @@
 # https://github.com/flathub/us.zoom.Zoom/issues/445
 rm -f $HOME/.zoom/data/cefcache/*/SingletonSocket
 
+# Support for Freedesktop.org user directory layout
+# Verify ~/Documents does not exist, to then create a symbolic link to the xdg documents directory
+if [[ ! -e ~/Documents ]]; then
+	ln -s "$(xdg-user-dir DOCUMENTS)" "${HOME}/Documents"
+fi
+
 TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID" exec /app/extra/zoom/ZoomLauncher "$@"


### PR DESCRIPTION
fixes #259, supersedes #262

To comply with custom and localized user document directories, this modification of the wrapper creates a symbolic link to the hard-coded Documents and hence bypasses (i.e. hacks around) this limitation of Zoom. (especially useful with #257 unfixed)

~~To do that, Zoom additionally needs file system read-only access to the user directory config at `xdg-config/user-dirs.dirs`.~~

see also:
* <https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html>
* <https://freedesktop.org/wiki/Software/xdg-user-dirs/>
* <https://cgit.freedesktop.org/xdg/xdg-user-dirs/tree/user-dirs.defaults>