### PR TITLE
Remove workaround that sets XDG_CURRENT_DESKTOP to gnome

### DIFF
--- a/zoom.sh
+++ b/zoom.sh
@@ -17,8 +17,6 @@ if [[ "$XDG_SESSION_TYPE" == "wayland" ]]; then
 
 		fi
 	fi
-	# Force XDG_CURRENT_DESKTOP to 'gnome' so that Zoom will not block portal screensharing
-	XDG_CURRENT_DESKTOP="gnome"
 fi
 
 TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID" exec /app/extra/zoom/ZoomLauncher "$@"


### PR DESCRIPTION
This was working around
https://support.zoom.us/hc/en-us/requests/14652478, which is fixed in
Zoom 5.11.10, which is already packaged here.

Fixes #348