### PR TITLE
Revert "Merge pull request #365 from flathub/update-606f636"

### DIFF
--- a/us.zoom.Zoom.appdata.xml
+++ b/us.zoom.Zoom.appdata.xml
@@ -24,7 +24,6 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="5.13.5.431" date="2023-01-16"/>
     <release version="5.13.4.711" date="2023-01-09"/>
     <release version="5.12.9.367" date="2022-11-28"/>
     <release version="5.12.6.173" date="2022-11-07"/>

--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -92,9 +92,9 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://cdn.zoom.us/prod/5.13.5.431/zoom_x86_64.tar.xz",
-                    "sha256": "506d19c7543b1095801c8e293aff200a243a7670ddc2b15156261de1bfed5fe8",
-                    "size": 166231152,
+                    "url": "https://cdn.zoom.us/prod/5.13.4.711/zoom_x86_64.tar.xz",
+                    "sha256": "fb31453183492ceba70581654c070fdb155bd363b1eb082a681b142a27f74814",
+                    "size": 147729432,
                     "x-checker-data": {
                         "type": "rotating-url",
                         "url": "https://zoom.us/client/latest/zoom_x86_64.tar.xz",


### PR DESCRIPTION
The new version seems to break :(

https://github.com/flathub/us.zoom.Zoom/issues/367

[📦 us.zoom.Zoom ~]$ /app/extra/zoom/zoom.real
/app/extra/zoom/zoom.real: error while loading shared libraries: libQt5QuickWidgets.so.5: cannot open shared object file: No such file or directory [📦 us.zoom.Zoom ~]$ LD_LIBRARY_PATH=/app/extra/zoom/Qt/lib /app/extra/zoom/zoom.real /app/extra/zoom/zoom.real: error while loading shared libraries: libgssapi_krb5.so.2: cannot open shared object file: No such file or directory

This reverts commit c16edf8755ceaa6e8d7859034f5e43546677ba03, reversing changes made to 3759ac7ee02fb8484ec1a014f810b3cb9e914877.