### PR TITLE
Update to 5.13.5.431, include krb5 as dep for bundled Qt.

### DIFF
--- a/us.zoom.Zoom.appdata.xml
+++ b/us.zoom.Zoom.appdata.xml
@@ -24,6 +24,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="5.13.5.431" date="2023-01-16"/>
     <release version="5.13.4.711" date="2023-01-09"/>
     <release version="5.12.9.367" date="2022-11-28"/>
     <release version="5.12.6.173" date="2022-11-07"/>

--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -25,6 +25,38 @@
     ],
     "modules": [
         {
+            "name": "krb5",
+            "subdir": "src",
+            "config-opts": [
+                "--disable-static",
+                "--disable-rpath"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://kerberos.org/dist/krb5/1.20/krb5-1.20.1.tar.gz",
+                    "sha256": "704aed49b19eb5a7178b34b2873620ec299db08752d6a8574f95d41879ab8851",
+                    "size": 8661660,
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 13287,
+                        "stable-only": true,
+                        "url-template": "https://kerberos.org/dist/krb5/$major.$minor/krb5-$major.$minor.$patch.tar.gz"
+                    }
+                }
+            ],
+            "cleanup": [
+                "/sbin",
+                "/bin",
+                "/var",
+                "/include",
+                "/lib/pkgconfig",
+                "/share/et",
+                "/share/examples",
+                "/share/man"
+            ]
+        },
+        {
             "name": "zoom",
             "buildsystem": "simple",
             "build-commands": [

--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -92,9 +92,9 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://cdn.zoom.us/prod/5.13.4.711/zoom_x86_64.tar.xz",
-                    "sha256": "fb31453183492ceba70581654c070fdb155bd363b1eb082a681b142a27f74814",
-                    "size": 147729432,
+                    "url": "https://cdn.zoom.us/prod/5.13.5.431/zoom_x86_64.tar.xz",
+                    "sha256": "506d19c7543b1095801c8e293aff200a243a7670ddc2b15156261de1bfed5fe8",
+                    "size": 166231152,
                     "x-checker-data": {
                         "type": "rotating-url",
                         "url": "https://zoom.us/client/latest/zoom_x86_64.tar.xz",

--- a/zoom-ld.so.conf
+++ b/zoom-ld.so.conf
@@ -1,2 +1,3 @@
 /app/extra/zoom
 /app/extra/zoom/cef
+/app/extra/zoom/Qt/lib


### PR DESCRIPTION
The new version of zoom bundles more Qt modules, including libQt5Network.so.5
that depends on libgssapi_krb5.so.2.
So include a stripped down version of krb5 for now.

fixes #367, fixes #369. closes #370.