### PR TITLE
Update us.zoom.Zoom.json

### DIFF
--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -41,7 +41,7 @@
                         "type": "anitya",
                         "project-id": 13287,
                         "stable-only": true,
-                        "url-template": "https://kerberos.org/dist/krb5/$major.$minor/krb5-$major.$minor.$patch.tar.gz"
+                        "url-template": "https://kerberos.org/dist/krb5/$major.$minor/krb5-$major.$minor.tar.gz"
                     }
                 }
             ],


### PR DESCRIPTION
Removing patch version from kerberos x-checker URL so that builds can succeed. Latest versions of krb5 don't have a patch version.