### PR TITLE
Remove outdated screenshot URL

### DIFF
--- a/us.zoom.Zoom.appdata.xml
+++ b/us.zoom.Zoom.appdata.xml
@@ -22,7 +22,6 @@
     <screenshot>
       <image type="source">https://explore.zoom.us/media/img-modernizemeeting_69f1e3a.png</image>
       <image type="source">https://explore.zoom.us/media/zfh-presentation.png</image>
-      <image type="source">https://support.zoom.us/hc/article_attachments/115017677066/Screen_Shot_2017-11-19_at_6.34.49_PM.png</image>
     </screenshot>
   </screenshots>
   <releases>


### PR DESCRIPTION
Closes #425

There are still two other screenshots where the URLs do work, so it didn't seem important to find a replacement for this one.

Hopefully this unblocks updating Zoom (#424).