### PR TITLE
Use html for krb5 update check

### DIFF
--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -37,10 +37,10 @@
                     "url": "https://kerberos.org/dist/krb5/1.21/krb5-1.21.tar.gz",
                     "sha256": "69f8aaff85484832df67a4bbacd99b9259bd95aab8c651fbbe65cdc9620ea93b",
                     "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 13287,
-                        "stable-only": true,
-                        "url-template": "https://kerberos.org/dist/krb5/$major.$minor/krb5-$major.$minor.tar.gz"
+                        "type": "html",
+                        "url": "https://kerberos.org/dist/",
+                        "version-pattern": "Kerberos V5 Release ([\\d\\.-]*) - current release",
+                        "url-template": "https://kerberos.org/dist/krb5/$major.$minor/krb5-$version.tar.gz"
                     }
                 }
             ],


### PR DESCRIPTION
The issue is that Anitya stores the `-final` suffix, so `$version` can't be used. But there's also not always a `$patch`, so there would never be PRs for patch updates.
With the HTML data checker this works correctly.

```
INFO    src.manifest: Checking 2 external data items
INFO    src.manifest: Started check [1/2] archive krb5/krb5-1.21.tar.gz (from us.zoom.Zoom.json)
INFO    src.manifest: Skipped check [2/2] archive zoom/zoom.tar.xz (from us.zoom.Zoom.json)
INFO    src.lib.externaldata: Source krb5-1.21.tar.gz: got new version 1.21.2
INFO    src.manifest: Finished check [2/2] archive krb5/krb5-1.21.tar.gz (from us.zoom.Zoom.json)
OUTDATED: krb5-1.21.tar.gz
 Has a new version:
  URL:       https://kerberos.org/dist/krb5/1.21/krb5-1.21.2.tar.gz
  MD5:       97d5f3a48235c53f6d537c877290d2af
  SHA1:      b88e9f819974a82d156654dccbd5ee3d1de8a98e
  SHA256:    9560941a9d843c0243a71b17a7ac6fe31c7cebb5bce3983db79e52ae7e850491
  SHA512:    4e09296b412383d53872661718dbfaa90201e0d85f69db48e57a8d4bd73c95a90c7ec7b6f0f325f6bc967f8d203b256b071c0191facf080aca0e2caec5d0ac49
  Size:      8622513
  Version:   1.21.2
  Timestamp: 2023-08-15 05:47:15

INFO    src.main: Check finished with 0 error(s)
```