### PR TITLE
Update to version 5.16.10.668

### DIFF
--- a/us.zoom.Zoom.appdata.xml
+++ b/us.zoom.Zoom.appdata.xml
@@ -25,6 +25,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="5.16.10.668" date="2023-11-20"/>
     <release version="5.16.6.382" date="2023-10-30"/>
     <release version="5.16.2.8828" date="2023-09-30"/>
     <release version="5.16.0.8131" date="2023-09-18"/>

--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -123,9 +123,9 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://cdn.zoom.us/prod/5.16.6.382/zoom_x86_64.tar.xz",
-                    "sha256": "8ee23aac5c360db0a7cfeaef26febddf16e0d232da205c8c81b0092a4243f63c",
-                    "size": 185859600,
+                    "url": "https://cdn.zoom.us/prod/5.16.10.668/zoom_x86_64.tar.xz",
+                    "sha256": "ed545671f370a84ef3955c541488b1e44c34f60cf44fd3f77723cb3284350106",
+                    "size": 186935984,
                     "x-checker-data": {
                         "type": "rotating-url",
                         "url": "https://zoom.us/client/latest/zoom_x86_64.tar.xz",


### PR DESCRIPTION
This was automatically opened as #424, and closed as superseded by newer versions. But so far, every 5.17.* version has crashed on launch.

Maybe this fixes some other issues without introducing the crash. I'll test it when it's built.