### PR TITLE
Try Zoom 5.17.1 with latest Zypak

### DIFF
--- a/us.zoom.Zoom.appdata.xml
+++ b/us.zoom.Zoom.appdata.xml
@@ -25,6 +25,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="5.17.1.1840" date="2023-12-27"/>
     <release version="5.16.6.382" date="2023-10-30"/>
     <release version="5.16.2.8828" date="2023-09-30"/>
     <release version="5.16.0.8131" date="2023-09-18"/>

--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -123,9 +123,9 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://cdn.zoom.us/prod/5.16.6.382/zoom_x86_64.tar.xz",
-                    "sha256": "8ee23aac5c360db0a7cfeaef26febddf16e0d232da205c8c81b0092a4243f63c",
-                    "size": 185859600,
+                    "url": "https://cdn.zoom.us/prod/5.17.1.1840/zoom_x86_64.tar.xz",
+                    "sha256": "b7eeac3c210673fa200b1f8e00e4785d9133ff1287237f66ef192a07cb296851",
+                    "size": 181740928,
                     "x-checker-data": {
                         "type": "rotating-url",
                         "url": "https://zoom.us/client/latest/zoom_x86_64.tar.xz",

--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -56,6 +56,16 @@
             ]
         },
         {
+            "name": "zypak",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/refi64/zypak",
+                    "commit": "ded79a2f8a509adc21834b95a9892073d4a91fdc"
+                }
+            ]
+        },
+        {
             "name": "zoom",
             "buildsystem": "simple",
             "build-commands": [

--- a/zoom-wrapper.sh
+++ b/zoom-wrapper.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
+export ZYPAK_CEF_LIBRARY_PATH=/app/extra/zoom/cef/libcef.so
 exec zypak-wrapper "$(readlink -f "$0")".real "$@"


### PR DESCRIPTION
And set `ZYPAK_CEF_LIBRARY_PATH` environment variable, added in https://github.com/refi64/zypak/commit/c7daf0cc5b82eb5f63a1665cf7d72ff267100690

I don't know if this will fix the crashes; I'll test it once built.