### PR TITLE
move `.zoom` folder to the app sandbox

### DIFF
--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -18,7 +18,7 @@
         "--share=network",
         "--device=all",
         "--filesystem=~/Documents/Zoom:create",
-        "--filesystem=~/.zoom:create",
+        "--persist=.zoom",
         "--env=QT_QPA_PLATFORM=",
         "--own-name=org.kde.*",
         "--talk-name=org.freedesktop.ScreenSaver"


### PR DESCRIPTION
by using add it as a persistent folder in the sandbox.  This change provides better sandbox for `.zoom` folder: other app with home dir permission will not be able to read this folder.  This change will also avoid polluting the user's home dir with non-standard dir (`.zoom`).