### PR TITLE
bump to v6.1.1

### DIFF
--- a/us.zoom.Zoom.appdata.xml
+++ b/us.zoom.Zoom.appdata.xml
@@ -28,9 +28,8 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="6.0.12.5501" date="2024-05-31">
-      <description></description>
-    </release>
+    <release version="6.1.1.443" date="2024-07-21"/>
+    <release version="6.0.12.5501" date="2024-05-31"/>
     <release version="6.0.10.5325" date="2024-05-20"/>
     <release version="6.0.2.4680" date="2024-04-19"/>
     <release version="6.0.0.4563" date="2024-04-15"/>

--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -123,9 +123,9 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://cdn.zoom.us/prod/6.0.12.5501/zoom_x86_64.tar.xz",
-                    "sha256": "4f2bba2f2543798dee05821b496f68cab0d8d4d4e301c646a0fedfb7a686b06c",
-                    "size": 202090468,
+                    "url": "https://cdn.zoom.us/prod/6.1.1.443/zoom_x86_64.tar.xz",
+                    "sha256": "d47f8afb6c108eb4baa94875b30627095c9dd3b0a65ba28a26e7953c4cdb65a8",
+                    "size": 206513816,
                     "x-checker-data": {
                         "type": "rotating-url",
                         "url": "https://zoom.us/client/latest/zoom_x86_64.tar.xz",


### PR DESCRIPTION
Can we bump to version 6.1.1? I tested starting zoom, signing in, and starting a meeting.