### PR TITLE
Wrap ZoomWebviewHost executable with zypak instead of zoom

### DIFF
--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -79,7 +79,7 @@
                     "commands": [
                         "tar xf zoom.tar.xz --no-same-owner",
                         "rm -f zoom.tar.xz",
-                        "sed -i 's,/usr/lib/xdg-desktop-portal,/app/lib/xdg-desktop-portal,g' /app/extra/zoom/zoom.real",
+                        "sed -i 's,/usr/lib/xdg-desktop-portal,/app/lib/xdg-desktop-portal,g' /app/extra/zoom/zoom",
                         "mv /app/extra/zoom/ZoomWebviewHost /app/extra/zoom/ZoomWebviewHost.real",
                         "cp /app/bin/zoom-wrapper.sh /app/extra/zoom/ZoomWebviewHost"
                     ]

--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -79,9 +79,9 @@
                     "commands": [
                         "tar xf zoom.tar.xz --no-same-owner",
                         "rm -f zoom.tar.xz",
-                        "mv /app/extra/zoom/zoom /app/extra/zoom/zoom.real",
                         "sed -i 's,/usr/lib/xdg-desktop-portal,/app/lib/xdg-desktop-portal,g' /app/extra/zoom/zoom.real",
-                        "cp /app/bin/zoom-wrapper.sh /app/extra/zoom/zoom"
+                        "mv /app/extra/zoom/ZoomWebviewHost /app/extra/zoom/ZoomWebviewHost.real",
+                        "cp /app/bin/zoom-wrapper.sh /app/extra/zoom/ZoomWebviewHost"
                     ]
                 },
                 {


### PR DESCRIPTION
Since 6.1, I've been getting messages 'It looks like "ZoomWebviewHost" crashed...", although the functionality I use still works. I finally got round to digging into this, and it looks like zoom's embedded chromium now has a separate executable, so that `ZoomWebviewHost` needs to be wrapped with Zypak instead of the main `zoom` executable.

I'm hoping this will also fix #473.