### PR TITLE
Revert "Update runtime to 24.08"

### DIFF
--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -1,9 +1,9 @@
 {
     "app-id": "us.zoom.Zoom",
     "base": "org.electronjs.Electron2.BaseApp",
-    "base-version": "24.08",
+    "base-version": "23.08",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "24.08",
+    "runtime-version": "23.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "zoom",
     "separate-locales": false,


### PR DESCRIPTION
This reverts commit da31bd7fd7ac90ee16e148c5d7004895ce0bf66d.

New Zoom versions have issue with pipewire >= 1.2, revert back to 23.08 runtime while the issue is not fixed
https://community.zoom.com/t5/Zoom-Meetings/share-screen-linux-wayland-broken/m-p/184687