### PR TITLE
Update runtime to 24.08

### DIFF
--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -1,9 +1,9 @@
 {
     "app-id": "us.zoom.Zoom",
     "base": "org.electronjs.Electron2.BaseApp",
-    "base-version": "23.08",
+    "base-version": "24.08",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "23.08",
+    "runtime-version": "24.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "zoom",
     "separate-locales": false,


### PR DESCRIPTION
As per the latest feedback ([Solved: re: share screen linux wayland broken](https://community.zoom.com/t5/Zoom-Meetings/share-screen-linux-wayland-broken/m-p/184687/page/4)), the issue with pipewire >= 1.2 seems to be fixed in Zoom 6.2.10.

So we can safely update to 24.08 now.