### PR TITLE
Update base and runtime versions for Zoom Flatpak

### DIFF
--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -1,9 +1,9 @@
 {
     "app-id": "us.zoom.Zoom",
     "base": "org.electronjs.Electron2.BaseApp",
-    "base-version": "24.08",
+    "base-version": "25.08",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "24.08",
+    "runtime-version": "25.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "zoom",
     "separate-locales": false,


### PR DESCRIPTION
Bump 'base-version' and 'runtime-version' from 24.08 to 25.08 in us.zoom.Zoom.json 