### PR TITLE
Add glu shared module to fix frozen video with avatar effects

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/us.zoom.Zoom.json
+++ b/us.zoom.Zoom.json
@@ -55,6 +55,7 @@
                 "/share/man"
             ]
         },
+        "shared-modules/glu/glu-9.json",
         {
             "name": "media-keys",
             "buildsystem": "simple",


### PR DESCRIPTION
Enabling an avatar effect freezes the video preview and outgoing video indefinitely. Blur and virtual backgrounds are unaffected.

Zoom runs video effects out-of-process in aomhost. Enabling an avatar spawns a second aomhost for the AvatarModuleAdapter, which dlopen()s libdvf.so, Zoom's GL renderer. That dlopen fails:

```
libGLU.so.1: cannot open shared object file: No such file or directory
```

libdvf.so actually imports no GLU symbols at all, and GLU is only needed to satisfy the dynamic loader. If Zoom fixes this in a future release, libGLU can be dropped from the flatpak.